### PR TITLE
build: convert png images to jpg when building epub

### DIFF
--- a/build-in-docker-epub.sh
+++ b/build-in-docker-epub.sh
@@ -4,4 +4,14 @@
 # コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
 # docker run -i -t -v $(pwd):/book vvakame/review:5.1 /bin/bash
 
+# reduce size of images
+FIND_COMMAND='find articles/images -type d -name cover -prune -o -type d -name chapter_title -prune -o -name "*.png" -print' # coverフォルダとchapter_titleフォルダを除いたpngファイルを抽出する
+IMAGEMAGICK_COMMAND='mogrify -format jpg -quality 75 -background white -alpha remove -alpha off' # JPG化してサイズを減らす
+docker run -v $(pwd)/articles:/articles --entrypoint=sh dpokidov/imagemagick:7.1.0-47-buster -c "${FIND_COMMAND} | xargs ${IMAGEMAGICK_COMMAND}"
+eval "${FIND_COMMAND}" | xargs rm -fr # PNGファイルを一時的に削除
+
 docker run -t --rm -v $(pwd):/book -v $(pwd)/articles/fonts/bizud:/usr/share/fonts/truetype/bizud vvakame/review:5.1 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"
+
+# restore images
+git restore articles/images
+git clean -fdx articles/images


### PR DESCRIPTION
カバー画像などpng指定されている一部の画像を除く、ビルド時にImageMagickでJPG化してサイズの削減を実施（品質75）。
PNGの解像度を落とす方法は画像がボケてしまった。
最終的にPDF全体で25MB→14.5MBに削減。