### PR TITLE
Adding extra information to the material duplication

### DIFF
--- a/articles/text_en/tuning_practice_asset.re
+++ b/articles/text_en/tuning_practice_asset.re
@@ -206,7 +206,8 @@ void OnDestroy()
 }
 //}
 Materials should be destroyed when they are finished being used (OnDestroy). Destroy materials at the appropriate timing according to the rules and specifications of the project. 
-
+By duplicating the material using the method in the code section "Example of Material being duplicated", the default material would leak out ~2.1kb (2021.3.22f1) so it would take ~500.000 duplication to leak 1GB of the memory.
+ 
 =={practice_asset_animation} Animation
 Animation is a widely used asset in both 2D and 3D. 
 This section introduces practices related to animation clips and animators. 


### PR DESCRIPTION
I think it would be useful to get a picture how much memory can be leak out in this so the reader would get a better perspective. (
(at least for me)
![image](https://user-images.githubusercontent.com/8947574/231850663-a6b1fbb8-5842-4255-b6f9-393bc3c5ceff.png)
