### PR TITLE
ci: update deprecated actions to v4

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -10,15 +10,15 @@ jobs:
     # uses v2 Stable version
     # https://github.com/actions/checkout
     - name: checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     # Build Artifacts
     - name: Build Japanese distribution file
       run: ./build-in-docker-epub.sh
     # Upload Distribution file
     - name: Upload distribution file to github artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: Output documents
+        name: Output documents (Japanese)
         path: ./articles/*.pdf
     # Build English artifacts
     - name: Build English distribution file
@@ -27,7 +27,7 @@ jobs:
         REVIEW_LANG: en
     # Upload English distribution file
     - name: Upload English distribution file to github artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: Output documents
+        name: Output documents (English)
         path: ./articles/*.pdf


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v3 -> v4
- Update `actions/upload-artifact` v3 -> v4
- Use unique artifact names per language (required by upload-artifact v4)

Fixes the CI failure: "This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)