### PR TITLE
[codex] add Rider-style code highlighting

### DIFF
--- a/articles/config-epub-jp.yml
+++ b/articles/config-epub-jp.yml
@@ -173,8 +173,8 @@ imagedir: images_jp
 # font_ext: ["ttf", "woff", "otf"]
 
 # ソースコードハイライトを利用する (rouge,pygmentsには外部gemが必要)
-highlight:
-  html: "rouge"
+# highlight:
+#   html: "rouge"
 #   latex: "listings"
 
 # カタログファイル名を指定する
@@ -469,6 +469,8 @@ pdfmaker:
 # という構成にする必要がある(インデントさせる)
 #
 webmaker:
+    highlight:
+        html: "rouge"
     stylesheet: ["style.css", "style-web.css"]
 
 # TechBooster Re:VIEW-Template独自設定

--- a/articles/config-epub-jp.yml
+++ b/articles/config-epub-jp.yml
@@ -173,8 +173,8 @@ imagedir: images_jp
 # font_ext: ["ttf", "woff", "otf"]
 
 # ソースコードハイライトを利用する (rouge,pygmentsには外部gemが必要)
-# highlight:
-#   html: "rouge"
+highlight:
+  html: "rouge"
 #   latex: "listings"
 
 # カタログファイル名を指定する

--- a/articles/style.css
+++ b/articles/style.css
@@ -152,6 +152,100 @@ th {
   background: #f8f9fa;
   font-weight: 600; }
 
+/* --- Rouge syntax highlighting --- */
+table.highlight,
+.rouge-table {
+  border: 0;
+  width: 100%;
+  margin-bottom: 16px;
+  background: #191a1c;
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 0.9em; }
+
+table.highlight td,
+.rouge-table td {
+  border: 0;
+  padding: 0;
+  vertical-align: top; }
+
+.rouge-gutter {
+  width: 1%;
+  color: #808080;
+  background: #191a1c;
+  border-right: 1px solid #404040;
+  text-align: right;
+  user-select: none; }
+
+.rouge-gutter pre,
+.rouge-code pre {
+  margin: 0;
+  padding: 0.75em 1em;
+  border: 0;
+  border-radius: 0;
+  overflow-x: auto;
+  line-height: 1.6; }
+
+.rouge-code {
+  width: 99%; }
+
+.rouge-code pre {
+  background: #191a1c;
+  color: #bdbdbd; }
+
+.highlight .k,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr {
+  color: #6c95eb;
+  font-weight: 400; }
+
+.highlight .kt {
+  color: #6c95eb;
+  font-weight: 400; }
+
+.highlight .nc {
+  color: #c191ff; }
+
+.highlight .nf {
+  color: #39cc9b; }
+
+.highlight .n,
+.highlight .p {
+  color: #bdbdbd; }
+
+.highlight .s,
+.highlight .s1,
+.highlight .s2 {
+  color: #c9a26d; }
+
+.highlight .m,
+.highlight .mi,
+.highlight .mf {
+  color: #ed94c0; }
+
+.highlight .c,
+.highlight .c1,
+.highlight .cm {
+  color: #85c46c;
+  font-style: italic; }
+
+.highlight .cp {
+  color: #6c95eb; }
+
+.highlight .na,
+.highlight .no,
+.highlight .nv,
+.highlight .vc,
+.highlight .vi,
+.highlight .vg {
+  color: #66c3cc; }
+
+.highlight .o,
+.highlight .ow {
+  color: #bdbdbd; }
+
 /* --- Links --- */
 a {
   color: #2563eb;

--- a/articles/style.scss
+++ b/articles/style.scss
@@ -109,6 +109,113 @@ div.footnote {
 	}
 }
 
+// Rouge syntax highlighting
+table.highlight,
+.rouge-table {
+	border: 0;
+	width: 100%;
+	margin-bottom: $paragraph-margin-bottom;
+	background: #191a1c;
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+table.highlight td,
+.rouge-table td {
+	border: 0;
+	padding: 0;
+	vertical-align: top;
+}
+
+.rouge-gutter {
+	width: 1%;
+	color: #808080;
+	background: #191a1c;
+	border-right: 1px solid #404040;
+	text-align: right;
+	user-select: none;
+}
+
+.rouge-gutter pre,
+.rouge-code pre {
+	margin: 0;
+	padding: 0.75em 1em;
+	overflow-x: auto;
+}
+
+.rouge-code {
+	width: 99%;
+}
+
+.rouge-code pre {
+	background: #191a1c;
+	color: #bdbdbd;
+}
+
+.highlight .k,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr {
+	color: #6c95eb;
+	font-weight: 400;
+}
+
+.highlight .kt {
+	color: #6c95eb;
+	font-weight: 400;
+}
+
+.highlight .nc {
+	color: #c191ff;
+}
+
+.highlight .nf {
+	color: #39cc9b;
+}
+
+.highlight .n,
+.highlight .p {
+	color: #bdbdbd;
+}
+
+.highlight .s,
+.highlight .s1,
+.highlight .s2 {
+	color: #c9a26d;
+}
+
+.highlight .m,
+.highlight .mi,
+.highlight .mf {
+	color: #ed94c0;
+}
+
+.highlight .c,
+.highlight .c1,
+.highlight .cm {
+	color: #85c46c;
+	font-style: italic;
+}
+
+.highlight .cp {
+	color: #6c95eb;
+}
+
+.highlight .na,
+.highlight .no,
+.highlight .nv,
+.highlight .vc,
+.highlight .vi,
+.highlight .vg {
+	color: #66c3cc;
+}
+
+.highlight .o,
+.highlight .ow {
+	color: #bdbdbd;
+}
+
 // ヘッダ
 .tb-header {
 	background-image: url(images/html_header.jpg);

--- a/articles/style.scss
+++ b/articles/style.scss
@@ -114,10 +114,11 @@ table.highlight,
 .rouge-table {
 	border: 0;
 	width: 100%;
-	margin-bottom: $paragraph-margin-bottom;
+	margin-bottom: $font-size;
 	background: #191a1c;
 	border-radius: 6px;
 	overflow: hidden;
+	font-size: 0.9em;
 }
 
 table.highlight td,
@@ -140,7 +141,10 @@ table.highlight td,
 .rouge-code pre {
 	margin: 0;
 	padding: 0.75em 1em;
+	border: 0;
+	border-radius: 0;
 	overflow-x: auto;
+	line-height: 1.6;
 }
 
 .rouge-code {


### PR DESCRIPTION
## Summary

Before:
<img width="812" height="556" alt="image" src="https://github.com/user-attachments/assets/bce6b925-a1d3-4692-a871-296b41f6b6c1" />
After:
<img width="804" height="492" alt="image" src="https://github.com/user-attachments/assets/dc9fc8d8-2e1c-41fe-a57a-2b087b8054e9" />


- Enable Rouge HTML syntax highlighting for Re:VIEW web output.
- Add Rider Islands Dark-inspired Rouge CSS for code blocks, line numbers, and C# token colors.
- Keep the change scoped to web/code presentation styles.

## Validation

- `npm_config_cache=/private/tmp/npm-cache npm ci --ignore-scripts`
- `npm_config_cache=/private/tmp/npm-cache npm run web`

## Notes

- The local HTTPS push path was blocked by organization SAML SSO, so the branch was pushed over SSH.