### PR TITLE
[codex] fix web highlight build config

### DIFF
--- a/articles/config-epub-jp.yml
+++ b/articles/config-epub-jp.yml
@@ -469,8 +469,6 @@ pdfmaker:
 # という構成にする必要がある(インデントさせる)
 #
 webmaker:
-    highlight:
-        html: "rouge"
     stylesheet: ["style.css", "style-web.css"]
 
 # TechBooster Re:VIEW-Template独自設定

--- a/articles/config-web-en.yml
+++ b/articles/config-web-en.yml
@@ -1,0 +1,6 @@
+# Web版（英語）用の上書き設定
+
+inherit: ["config-epub-en.yml"]
+
+highlight:
+  html: "rouge"

--- a/articles/config-web-jp.yml
+++ b/articles/config-web-jp.yml
@@ -1,0 +1,6 @@
+# Web版用の上書き設定
+
+inherit: ["config-epub-jp.yml"]
+
+highlight:
+  html: "rouge"

--- a/build-web.sh
+++ b/build-web.sh
@@ -9,12 +9,12 @@ mkdir -p "$OUTDIR/ja" "$OUTDIR/en"
 
 # Build Japanese
 echo "=== Building Japanese ==="
-REVIEW_CONFIG_FILE=config-epub-jp.yml npx grunt web
+REVIEW_CONFIG_FILE=config-web-jp.yml npx grunt web
 cp -r "$WEBROOT/"* "$OUTDIR/ja/"
 
 # Build English
 echo "=== Building English ==="
-REVIEW_CONFIG_FILE=config-epub-en.yml npx grunt web
+REVIEW_CONFIG_FILE=config-web-en.yml npx grunt web
 cp -r "$WEBROOT/"* "$OUTDIR/en/"
 
 # Generate search indices


### PR DESCRIPTION
## Summary
- Add web-specific Re:VIEW config files that enable Rouge at the top level for web builds
- Keep EPUB configs without HTML highlighting
- Switch build-web.sh to use the web configs for Japanese and English output

## Verification
- bundle exec ruby -rreview -rreview/configure -rreview/highlighter ... confirmed web configs return html="rouge" and EPUB configs return false
- Sample C# text produces Rouge markup for web config and stays plain for EPUB config
- git diff --check origin/main..HEAD